### PR TITLE
Docs - updating the reference docs for get_publications and api_url

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,7 +1,5 @@
 # Reference
 
-This page is generated from the Python source code and docstrings.
-
 # API URL
 
 ::: eesyapi.api_url.api_url

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,18 +2,10 @@
 
 This page is generated from the Python source code and docstrings.
 
-## API URL
+# API URL
 
-::: eesyapi.api_url
+::: eesyapi.api_url.api_url
 
-## API URL pages
+## Get publications 
 
-::: eesyapi.api_url_pages
-
-## API URL query
-
-::: eesyapi.api_url_query
-
-## Utilities
-
-::: eesyapi.utils
+::: eesyapi.get_publications.get_publications

--- a/src/eesyapi/api_url.py
+++ b/src/eesyapi/api_url.py
@@ -6,46 +6,79 @@ Url builder for Explore Education Statistics (EES) API
 """
 
 from urllib.parse import urlencode
+from typing import Optional, List, Dict, Any 
 
 def api_url(
     endpoint: str = "get-publications",
-    search = None, 
-    publication_id = None, 
-    dataset_id = None, 
-    indicators = None, 
-    time_periods = None, 
-    geographic_levels = None,
-    locations = None, 
-    filter_items = None, 
-    dataset_version = None, 
-    ees_environment = None, 
-    api_version = None, 
-    page_size = None, 
-    page = None, 
-    verbose = False ):
-        
+    search: Optional[str] = None, 
+    publication_id: Optional[str] = None, 
+    dataset_id: Optional[str] = None, 
+    indicators: Optional[list] = None, 
+    time_periods: Optional[list] = None, 
+    geographic_levels: Optional[list] = None,
+    locations: Optional[list] = None, 
+    filter_items: Optional[list] = None, 
+    dataset_version: Optional[str] = None, 
+    ees_environment: Optional[str] = None, 
+    api_version: Optional[str] = None, 
+    page_size: Optional[int] = None, 
+    page: Optional[int] = None, 
+    verbose: bool = False 
+    ) -> List[Dict]:
+     """
+    Fetch publication records from the Explore Education Statistics API.
+
+    If a specific page is provided, only that page is returned.
+    If page is None, the function fetches all available pages and combines
+    the results into one list.
+
+    Args:
+          search: Optional search keyword for filtering publications.
+          publication_id: Publication ID key 
+          dataset_id: Data set ID key
+          indicators: Indicators for data set query 
+          time_periods: Time periods for data set query
+          geographic_levels: Geographic levels for data set query
+          locations: Locations for data set query
+          filter_items: Filter items for data set query
+          dataset_version: Dataset version
+          ees_environment: API environment, such as dev, test, preprod or prod.
+          api_version: API version to use.
+          page_size: Number of records to return per page.
+          page: Specific page number to fetch. If None, all pages are fetched.
+          verbose: If True, prints the API URLs being requested.
+
+    Returns:
+        str: The API URL for the requested endpoint.
+
+    Example:
+        ```python
+        api_url()
+        ```
+
+    """     
 #Default Values
 
-    if ees_environment is None:
+     if ees_environment is None:
         ees_environment = "prod"
     
-    if api_version is None:
+     if api_version is None:
            api_version = "1"
 
 #Base URL
 
-    _base_urls = {
+     _base_urls = {
         "dev": "https://pp-api.education.gov.uk/statistics-dev/", 
         "test": "https://pp-api.education.gov.uk/statistics-test/", 
         "preprod": "https://pp-api.education.gov.uk/statistics-preprod/", 
         "prod": "https://api.education.gov.uk/statistics/"
-    }
+     }
 
-    base = _base_urls[ees_environment] + "v" + api_version + "/"
+     base = _base_urls[ees_environment] + "v" + api_version + "/"
 
 #Get Publications 
 
-    if endpoint == "get-publications":
+     if endpoint == "get-publications":
          
          params = {}
 
@@ -66,7 +99,7 @@ def api_url(
 
 # Get Data Catalogue
 
-    elif endpoint == "get-data-catalogue":
+     elif endpoint == "get-data-catalogue":
 
          if not publication_id:
               raise ValueError("publication_id is required")
@@ -87,7 +120,7 @@ def api_url(
 
 # Dataset Endpoints     
 
-    else:
+     else:
          
          if not dataset_id:
               raise ValueError("dataset_id is required")
@@ -152,15 +185,7 @@ def api_url(
 
 # Verbose
 
-    if verbose:
+     if verbose:
          print("Generated URL:")
          print(url)
-    return url 
-
-
-# print(api_url())
-print(api_url(
-    endpoint="get-data-catalogue", 
-    publication_id="8b7474f9-5870-4ecc-7557-08da5f64dcf1",
-    filter_items="Absence reason"
-))
+     return url 

--- a/src/eesyapi/get_publications.py
+++ b/src/eesyapi/get_publications.py
@@ -53,7 +53,7 @@ def get_publications(
         page: Optional[int] = None, 
         verbose: bool = False
 ) -> List[Dict]:
-     """
+    """
     Fetch publication records from the Explore Education Statistics API.
 
     If a specific page is provided, only that page is returned.
@@ -73,14 +73,22 @@ def get_publications(
 
     Raises:
         Exception: If the API request returns a non-200 status code.
+
+        
+    Example:
+        ```python
+        get_publications()
+        get_publications(search = "attendance")
+        ```
+
     """
     # Validate page_size before creating the API request.
-     validate_page_size(page_size)
+    validate_page_size(page_size)
 
-     validate_environment(ees_environment)
+    validate_environment(ees_environment)
 
    # Build the API URL for the first request.
-     url = api_url(
+    url = api_url(
         endpoint="get-publications",
         search = search, 
         ees_environment=ees_environment,
@@ -90,17 +98,17 @@ def get_publications(
         verbose=verbose
     )
     # Print the API URL when verbose mode is enabled.
-     if verbose:
+    if verbose:
         print(f"GET {url}")
    # Send GET request to the API.
-     response = requests.get(url)
+    response = requests.get(url)
   # Raise an error if the API response is not successful.
-     if response.status_code !=200:
+    if response.status_code !=200:
             raise Exception(f"API Error: {response.status_code}")
     # Convert API response to JSON.   
-     data = response.json()
+    data = response.json()
    # If page is not provided, fetch all pages automatically.
-     if page is None:
+    if page is None:
         total_pages = data.get("paging", {}).get("totalPages",1)
        # If there is more than one page, fetch pages 2 to total_pages.
         if total_pages > 1:
@@ -131,7 +139,7 @@ def get_publications(
                 data["results"].extend(data_page.get("results",[]))
 
     # Warn user if requested page is beyond available pages.
-     warning_max_pages(data)
+    warning_max_pages(data)
     # Return only the publication records.
-     return data.get("results",[])
+    return data.get("results",[])
 


### PR DESCRIPTION
## Overview of changes

The documentation was a little lacking for api_url and there was a lack of examples across the board. Changes as follows:

- api_url documentation now gives comprehensive list of possible variables
- Both api_url and get_publications have basic examples included.

## Why are these changes being made?

Improve the documentation

